### PR TITLE
feat: Add `ClusterProfile` as an environment variable option

### DIFF
--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -85,9 +85,6 @@ func NewControllers(
 		informer.NewNodePoolController(kubeClient, cloudProvider, cluster),
 		informer.NewNodeClaimController(kubeClient, cloudProvider, cluster),
 		termination.NewController(clock, kubeClient, cloudProvider, terminator.NewTerminator(clock, kubeClient, evictionQueue, recorder), recorder),
-		metricspod.NewController(kubeClient, cluster),
-		metricsnodepool.NewController(kubeClient, cloudProvider),
-		metricsnode.NewController(cluster),
 		nodepoolreadiness.NewController(kubeClient, cloudProvider),
 		nodepoolregistrationhealth.NewController(kubeClient, cloudProvider),
 		nodepoolcounter.NewController(kubeClient, cloudProvider, cluster),
@@ -99,25 +96,34 @@ func NewControllers(
 		nodeclaimdisruption.NewController(clock, kubeClient, cloudProvider),
 		nodeclaimhydration.NewController(kubeClient, cloudProvider),
 		nodehydration.NewController(kubeClient, cloudProvider),
-		status.NewController[*v1.NodeClaim](
-			kubeClient,
-			mgr.GetEventRecorderFor("karpenter"),
-			status.EmitDeprecatedMetrics,
-			status.WithHistogramBuckets(prometheus.ExponentialBuckets(0.5, 2, 15)), // 0.5, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192
-			status.WithLabels(append(lo.Map(cloudProvider.GetSupportedNodeClasses(), func(obj status.Object, _ int) string { return v1.NodeClassLabelKey(object.GVK(obj).GroupKind()) }), v1.NodePoolLabelKey)...),
-		),
-		status.NewController[*v1.NodePool](
-			kubeClient,
-			mgr.GetEventRecorderFor("karpenter"),
-			status.EmitDeprecatedMetrics,
-			status.WithHistogramBuckets(prometheus.ExponentialBuckets(0.5, 2, 15)), // 0.5, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192
-		),
-		status.NewGenericObjectController[*corev1.Node](
-			kubeClient,
-			mgr.GetEventRecorderFor("karpenter"),
-			status.WithHistogramBuckets(prometheus.ExponentialBuckets(0.5, 2, 15)), // 0.5, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192
-			status.WithLabels(append(lo.Map(cloudProvider.GetSupportedNodeClasses(), func(obj status.Object, _ int) string { return v1.NodeClassLabelKey(object.GVK(obj).GroupKind()) }), v1.NodePoolLabelKey, v1.NodeInitializedLabelKey)...),
-		),
+	}
+
+	opts := options.FromContext(ctx)
+	highScaleProfile := opts.ClusterProfile == options.ClusterProfileHighScale
+	if !highScaleProfile {
+		controllers = append(controllers, metricspod.NewController(kubeClient, cluster),
+			metricsnodepool.NewController(kubeClient, cloudProvider),
+			metricsnode.NewController(cluster),
+			status.NewController[*v1.NodeClaim](
+				kubeClient,
+				mgr.GetEventRecorderFor("karpenter"),
+				status.EmitDeprecatedMetrics,
+				status.WithHistogramBuckets(prometheus.ExponentialBuckets(0.5, 2, 15)), // 0.5, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192
+				status.WithLabels(append(lo.Map(cloudProvider.GetSupportedNodeClasses(), func(obj status.Object, _ int) string { return v1.NodeClassLabelKey(object.GVK(obj).GroupKind()) }), v1.NodePoolLabelKey)...),
+			),
+			status.NewController[*v1.NodePool](
+				kubeClient,
+				mgr.GetEventRecorderFor("karpenter"),
+				status.EmitDeprecatedMetrics,
+				status.WithHistogramBuckets(prometheus.ExponentialBuckets(0.5, 2, 15)), // 0.5, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192
+			),
+			status.NewGenericObjectController[*corev1.Node](
+				kubeClient,
+				mgr.GetEventRecorderFor("karpenter"),
+				status.WithHistogramBuckets(prometheus.ExponentialBuckets(0.5, 2, 15)), // 0.5, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192
+				status.WithLabels(append(lo.Map(cloudProvider.GetSupportedNodeClasses(), func(obj status.Object, _ int) string { return v1.NodeClassLabelKey(object.GVK(obj).GroupKind()) }), v1.NodePoolLabelKey, v1.NodeInitializedLabelKey)...),
+			),
+		)
 	}
 
 	// The cloud provider must define status conditions for the node repair controller to use to detect unhealthy nodes

--- a/pkg/controllers/disruption/queue.go
+++ b/pkg/controllers/disruption/queue.go
@@ -46,6 +46,7 @@ import (
 
 	pscheduling "sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling"
 	operatorlogging "sigs.k8s.io/karpenter/pkg/operator/logging"
+	"sigs.k8s.io/karpenter/pkg/operator/options"
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	disruptionevents "sigs.k8s.io/karpenter/pkg/controllers/disruption/events"
@@ -58,10 +59,8 @@ import (
 )
 
 const (
-	queueBaseDelay          = 1 * time.Second
-	queueMaxDelay           = 10 * time.Second
-	maxRetryDuration        = 10 * time.Minute
-	maxConcurrentReconciles = 100
+	queueBaseDelay = 1 * time.Second
+	queueMaxDelay  = 10 * time.Second
 )
 
 type UnrecoverableError struct {
@@ -109,7 +108,10 @@ func NewQueue(kubeClient client.Client, recorder events.Recorder, cluster *state
 	return queue
 }
 
-func (q *Queue) Register(_ context.Context, m manager.Manager) error {
+func (q *Queue) Register(ctx context.Context, m manager.Manager) error {
+	opts := options.FromContext(ctx)
+	highScaleProfile := opts.ClusterProfile == options.ClusterProfileHighScale
+	maxConcurrentReconciles := lo.Ternary(highScaleProfile, 1000, 100)
 	return controllerruntime.NewControllerManagedBy(m).
 		Named("disruption.queue").
 		WatchesRawSource(source.Channel(q.source, &handler.TypedEnqueueRequestForObject[*v1.NodeClaim]{})).
@@ -170,6 +172,9 @@ func (q *Queue) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim) (reconci
 func (q *Queue) waitOrTerminate(ctx context.Context, cmd *Command) (err error) {
 	// Wrap an error in an unrecoverable error if it timed out
 	defer func() {
+		opts := options.FromContext(ctx)
+		highScaleProfile := opts.ClusterProfile == options.ClusterProfileHighScale
+		maxRetryDuration := lo.Ternary(highScaleProfile, time.Hour, 10*time.Minute)
 		if q.clock.Since(cmd.CreationTimestamp) > maxRetryDuration {
 			err = NewUnrecoverableError(serrors.Wrap(fmt.Errorf("command reached timeout, %w", err), "duration", q.clock.Since(cmd.CreationTimestamp)))
 		}

--- a/pkg/controllers/disruption/queue_test.go
+++ b/pkg/controllers/disruption/queue_test.go
@@ -20,9 +20,11 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/samber/lo"
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter/pkg/operator/options"
 
 	"sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling"
 
@@ -412,6 +414,49 @@ var _ = Describe("Queue", func() {
 			ExpectNodeClaimsCascadeDeletion(ctx, env.Client, nodeClaim2)
 			// And expect the nodeClaim and node to be deleted
 			ExpectNotFound(ctx, env.Client, nodeClaim2, node2)
+		})
+	})
+	Context("HighScale Profile", func() {
+		It("should use higher timeout for HighScale profile", func() {
+			ctxHighScale := options.ToContext(ctx, test.Options(test.OptionsFields{
+				ClusterProfile: lo.ToPtr(options.ClusterProfileHighScale),
+			}))
+			ExpectApplied(ctxHighScale, env.Client, nodeClaim1, node1, nodePool)
+			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctxHighScale, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{node1}, []*v1.NodeClaim{nodeClaim1})
+			stateNode := ExpectStateNodeExistsForNodeClaim(cluster, nodeClaim1)
+
+			nct := scheduling.NewNodeClaimTemplate(nodePool)
+			nct.InstanceTypeOptions = append([]*cloudprovider.InstanceType{}, cloudProvider.InstanceTypes...)
+			replacements := []*disruption.Replacement{
+				{
+					NodeClaim: &scheduling.NodeClaim{NodeClaimTemplate: *nct},
+				},
+			}
+
+			cmd := &disruption.Command{
+				Method:            disruption.NewDrift(env.Client, cluster, prov, recorder),
+				CreationTimestamp: fakeClock.Now(),
+				ID:                uuid.New(),
+				Results:           scheduling.Results{},
+				Candidates:        []*disruption.Candidate{{StateNode: stateNode}},
+				Replacements:      replacements,
+			}
+			Expect(queue.StartCommand(ctxHighScale, cmd)).To(BeNil())
+
+			// Step the clock (should not timeout with HighScale profile)
+			fakeClock.Step(11 * time.Minute)
+
+			ExpectObjectReconciled(ctxHighScale, env.Client, queue, stateNode.NodeClaim)
+			node1 = ExpectNodeExists(ctxHighScale, env.Client, node1.Name)
+			// Node should still be tainted (as not timed out)
+			Expect(node1.Spec.Taints).To(ContainElement(v1.DisruptedNoScheduleTaint))
+
+			// Step the clock to total of 61 min (should timeout with HighScale profile)
+			fakeClock.Step(50 * time.Minute)
+
+			ExpectObjectReconciled(ctxHighScale, env.Client, queue, stateNode.NodeClaim)
+			node1 = ExpectNodeExists(ctxHighScale, env.Client, node1.Name)
+			Expect(node1.Spec.Taints).ToNot(ContainElement(v1.DisruptedNoScheduleTaint))
 		})
 	})
 })

--- a/pkg/controllers/node/health/controller.go
+++ b/pkg/controllers/node/health/controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/awslabs/operatorpkg/reasonable"
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -32,6 +33,7 @@ import (
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -41,6 +43,7 @@ import (
 	"sigs.k8s.io/karpenter/pkg/events"
 	"sigs.k8s.io/karpenter/pkg/metrics"
 	"sigs.k8s.io/karpenter/pkg/operator/injection"
+	"sigs.k8s.io/karpenter/pkg/operator/options"
 	nodeutils "sigs.k8s.io/karpenter/pkg/utils/node"
 	"sigs.k8s.io/karpenter/pkg/utils/pretty"
 )
@@ -65,11 +68,19 @@ func NewController(kubeClient client.Client, cloudProvider cloudprovider.CloudPr
 	}
 }
 
-func (c *Controller) Register(_ context.Context, m manager.Manager) error {
-	return controllerruntime.NewControllerManagedBy(m).
+func (c *Controller) Register(ctx context.Context, m manager.Manager) error {
+	opts := options.FromContext(ctx)
+	highScaleProfile := opts.ClusterProfile == options.ClusterProfileHighScale
+	baseBuild := controllerruntime.NewControllerManagedBy(m).
 		Named("node.health").
-		For(&corev1.Node{}, builder.WithPredicates(nodeutils.IsManagedPredicateFuncs(c.cloudProvider))).
-		Complete(reconcile.AsReconciler(m.GetClient(), c))
+		For(&corev1.Node{}, builder.WithPredicates(nodeutils.IsManagedPredicateFuncs(c.cloudProvider)))
+	if highScaleProfile {
+		baseBuild = baseBuild.WithOptions(controller.Options{
+			RateLimiter:             reasonable.RateLimiter(),
+			MaxConcurrentReconciles: 1000,
+		})
+	}
+	return baseBuild.Complete(reconcile.AsReconciler(m.GetClient(), c))
 }
 
 func (c *Controller) Reconcile(ctx context.Context, node *corev1.Node) (reconcile.Result, error) {

--- a/pkg/controllers/node/termination/controller.go
+++ b/pkg/controllers/node/termination/controller.go
@@ -41,6 +41,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"sigs.k8s.io/karpenter/pkg/operator/options"
 	"sigs.k8s.io/karpenter/pkg/utils/pretty"
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
@@ -385,18 +386,29 @@ func (c *Controller) nodeTerminationTime(node *corev1.Node, nodeClaim *v1.NodeCl
 	return &expirationTime, nil
 }
 
-func (c *Controller) Register(_ context.Context, m manager.Manager) error {
+func (c *Controller) Register(ctx context.Context, m manager.Manager) error {
+	opts := options.FromContext(ctx)
+	highScaleProfile := opts.ClusterProfile == options.ClusterProfileHighScale
+	maxConcurrentReconciles := lo.Ternary(highScaleProfile, 5000, 100)
+	var rateLimiter workqueue.TypedRateLimiter[reconcile.Request]
+	if highScaleProfile {
+		rateLimiter = workqueue.NewTypedMaxOfRateLimiter[reconcile.Request](
+			workqueue.NewTypedItemExponentialFailureRateLimiter[reconcile.Request](100*time.Millisecond, 10*time.Second),
+		)
+	} else {
+		rateLimiter = workqueue.NewTypedMaxOfRateLimiter[reconcile.Request](
+			workqueue.NewTypedItemExponentialFailureRateLimiter[reconcile.Request](100*time.Millisecond, 10*time.Second),
+			// 10 qps, 100 bucket size
+			&workqueue.TypedBucketRateLimiter[reconcile.Request]{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
+		)
+	}
 	return controllerruntime.NewControllerManagedBy(m).
 		Named("node.termination").
 		For(&corev1.Node{}, builder.WithPredicates(nodeutils.IsManagedPredicateFuncs(c.cloudProvider))).
 		WithOptions(
 			controller.Options{
-				RateLimiter: workqueue.NewTypedMaxOfRateLimiter[reconcile.Request](
-					workqueue.NewTypedItemExponentialFailureRateLimiter[reconcile.Request](100*time.Millisecond, 10*time.Second),
-					// 10 qps, 100 bucket size
-					&workqueue.TypedBucketRateLimiter[reconcile.Request]{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
-				),
-				MaxConcurrentReconciles: 100,
+				RateLimiter:             rateLimiter,
+				MaxConcurrentReconciles: maxConcurrentReconciles,
 			},
 		).
 		Complete(reconcile.AsReconciler(m.GetClient(), c))

--- a/pkg/controllers/node/termination/terminator/eviction.go
+++ b/pkg/controllers/node/termination/terminator/eviction.go
@@ -48,6 +48,7 @@ import (
 	terminatorevents "sigs.k8s.io/karpenter/pkg/controllers/node/termination/terminator/events"
 	"sigs.k8s.io/karpenter/pkg/events"
 	"sigs.k8s.io/karpenter/pkg/operator/injection"
+	"sigs.k8s.io/karpenter/pkg/operator/options"
 	nodeutils "sigs.k8s.io/karpenter/pkg/utils/node"
 	podutils "sigs.k8s.io/karpenter/pkg/utils/pod"
 )
@@ -108,7 +109,21 @@ func (q *Queue) Name() string {
 	return "eviction-queue"
 }
 
-func (q *Queue) Register(_ context.Context, m manager.Manager) error {
+func (q *Queue) Register(ctx context.Context, m manager.Manager) error {
+	opts := options.FromContext(ctx)
+	highScaleProfile := opts.ClusterProfile == options.ClusterProfileHighScale
+	maxConcurrentReconciles := lo.Ternary(highScaleProfile, 5000, 100)
+	var rateLimiter workqueue.TypedRateLimiter[reconcile.Request]
+	if highScaleProfile {
+		rateLimiter = workqueue.NewTypedMaxOfRateLimiter[reconcile.Request](
+			workqueue.NewTypedItemExponentialFailureRateLimiter[reconcile.Request](evictionQueueBaseDelay, evictionQueueMaxDelay),
+		)
+	} else {
+		rateLimiter = workqueue.NewTypedMaxOfRateLimiter[reconcile.Request](
+			workqueue.NewTypedItemExponentialFailureRateLimiter[reconcile.Request](evictionQueueBaseDelay, evictionQueueMaxDelay),
+			&workqueue.TypedBucketRateLimiter[reconcile.Request]{Limiter: rate.NewLimiter(rate.Limit(100), 1000)},
+		)
+	}
 	return controllerruntime.NewControllerManagedBy(m).
 		Named(q.Name()).
 		WatchesRawSource(source.Channel(q.source, handler.TypedFuncs[*corev1.Pod, reconcile.Request]{
@@ -119,11 +134,8 @@ func (q *Queue) Register(_ context.Context, m manager.Manager) error {
 			},
 		})).
 		WithOptions(controller.Options{
-			RateLimiter: workqueue.NewTypedMaxOfRateLimiter[reconcile.Request](
-				workqueue.NewTypedItemExponentialFailureRateLimiter[reconcile.Request](evictionQueueBaseDelay, evictionQueueMaxDelay),
-				&workqueue.TypedBucketRateLimiter[reconcile.Request]{Limiter: rate.NewLimiter(rate.Limit(100), 1000)},
-			),
-			MaxConcurrentReconciles: 100,
+			RateLimiter:             rateLimiter,
+			MaxConcurrentReconciles: maxConcurrentReconciles,
 		}).
 		Complete(reconcile.AsReconciler(m.GetClient(), q))
 }

--- a/pkg/controllers/nodeclaim/lifecycle/controller.go
+++ b/pkg/controllers/nodeclaim/lifecycle/controller.go
@@ -47,6 +47,7 @@ import (
 	"sigs.k8s.io/karpenter/pkg/events"
 	"sigs.k8s.io/karpenter/pkg/metrics"
 	"sigs.k8s.io/karpenter/pkg/operator/injection"
+	"sigs.k8s.io/karpenter/pkg/operator/options"
 	nodeclaimutils "sigs.k8s.io/karpenter/pkg/utils/nodeclaim"
 	"sigs.k8s.io/karpenter/pkg/utils/result"
 )
@@ -79,7 +80,21 @@ func NewController(clk clock.Clock, kubeClient client.Client, cloudProvider clou
 	}
 }
 
-func (c *Controller) Register(_ context.Context, m manager.Manager) error {
+func (c *Controller) Register(ctx context.Context, m manager.Manager) error {
+	opts := options.FromContext(ctx)
+	highScaleProfile := opts.ClusterProfile == options.ClusterProfileHighScale
+	maxConcurrentReconciles := lo.Ternary(highScaleProfile, 5000, 1000)
+	var rateLimiter workqueue.TypedRateLimiter[reconcile.Request]
+	if highScaleProfile {
+		rateLimiter = workqueue.NewTypedItemExponentialFailureRateLimiter[reconcile.Request](time.Second, time.Second*10)
+	} else {
+		rateLimiter = workqueue.NewTypedMaxOfRateLimiter[reconcile.Request](
+			// back off until last attempt occurs ~90 seconds before nodeclaim expiration
+			workqueue.NewTypedItemExponentialFailureRateLimiter[reconcile.Request](time.Second, time.Minute),
+			// 10 qps, 100 bucket size
+			&workqueue.TypedBucketRateLimiter[reconcile.Request]{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
+		)
+	}
 	return controllerruntime.NewControllerManagedBy(m).
 		Named(c.Name()).
 		For(&v1.NodeClaim{}, builder.WithPredicates(nodeclaimutils.IsManagedPredicateFuncs(c.cloudProvider))).
@@ -88,13 +103,8 @@ func (c *Controller) Register(_ context.Context, m manager.Manager) error {
 			nodeclaimutils.NodeEventHandler(c.kubeClient, c.cloudProvider),
 		).
 		WithOptions(controller.Options{
-			RateLimiter: workqueue.NewTypedMaxOfRateLimiter[reconcile.Request](
-				// back off until last attempt occurs ~90 seconds before nodeclaim expiration
-				workqueue.NewTypedItemExponentialFailureRateLimiter[reconcile.Request](time.Second, time.Minute),
-				// 10 qps, 100 bucket size
-				&workqueue.TypedBucketRateLimiter[reconcile.Request]{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
-			),
-			MaxConcurrentReconciles: 1000, // higher concurrency limit since we want fast reaction to node syncing and launch
+			RateLimiter:             rateLimiter,
+			MaxConcurrentReconciles: maxConcurrentReconciles, // higher concurrency limit since we want fast reaction to node syncing and launch
 		}).
 		Complete(reconcile.AsReconciler(m.GetClient(), c))
 }

--- a/pkg/controllers/nodeclaim/lifecycle/liveness.go
+++ b/pkg/controllers/nodeclaim/lifecycle/liveness.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/samber/lo"
 	"k8s.io/apimachinery/pkg/api/errors"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -32,6 +33,7 @@ import (
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/metrics"
+	"sigs.k8s.io/karpenter/pkg/operator/options"
 )
 
 type Liveness struct {
@@ -39,12 +41,10 @@ type Liveness struct {
 	kubeClient client.Client
 }
 
-// registrationTimeout is a heuristic time that we expect the node to register within
 // launchTimeout is a heuristic time that we expect to be able to launch within
 // If we don't see the node within this time, then we should delete the NodeClaim and try again
 
 const (
-	registrationTimeout       = time.Minute * 15
 	registrationTimeoutReason = "registration_timeout"
 	launchTimeout             = time.Minute * 5
 	launchTimeoutReason       = "launch_timeout"
@@ -55,16 +55,10 @@ type NodeClaimTimeout struct {
 	reason   string
 }
 
-var (
-	RegistrationTimeout = NodeClaimTimeout{
-		duration: registrationTimeout,
-		reason:   registrationTimeoutReason,
-	}
-	LaunchTimeout = NodeClaimTimeout{
-		duration: launchTimeout,
-		reason:   launchTimeoutReason,
-	}
-)
+var LaunchTimeout = NodeClaimTimeout{
+	duration: launchTimeout,
+	reason:   launchTimeoutReason,
+}
 
 //nolint:gocyclo
 func (l *Liveness) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim) (reconcile.Result, error) {
@@ -90,6 +84,14 @@ func (l *Liveness) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim) (reco
 	}
 	if registered == nil {
 		return reconcile.Result{Requeue: true}, nil
+	}
+	opts := options.FromContext(ctx)
+	highScaleProfile := opts.ClusterProfile == options.ClusterProfileHighScale
+	// registrationTimeout is a heuristic time that we expect the node to register within
+	registrationTimeout := lo.Ternary(highScaleProfile, time.Hour, time.Minute*15)
+	RegistrationTimeout := NodeClaimTimeout{
+		duration: registrationTimeout,
+		reason:   registrationTimeoutReason,
 	}
 	// If the Registered statusCondition hasn't gone True during the timeout since we first updated it, we should terminate the NodeClaim
 	// NOTE: Timeout has to be stored and checked in the same place since l.clock can advance after the check causing a race

--- a/pkg/controllers/nodeclaim/lifecycle/liveness_test.go
+++ b/pkg/controllers/nodeclaim/lifecycle/liveness_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/awslabs/operatorpkg/status"
+	"github.com/samber/lo"
 
 	operatorpkg "github.com/awslabs/operatorpkg/test/expectations"
 	. "github.com/onsi/ginkgo/v2"
@@ -30,6 +31,7 @@ import (
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider/fake"
+	"sigs.k8s.io/karpenter/pkg/operator/options"
 	"sigs.k8s.io/karpenter/pkg/test"
 	. "sigs.k8s.io/karpenter/pkg/test/expectations"
 )
@@ -310,5 +312,45 @@ var _ = Describe("Liveness", func() {
 		_ = ExpectObjectReconcileFailed(ctx, env.Client, nodeClaimController, nodeClaim)
 		ExpectFinalizersRemoved(ctx, env.Client, nodeClaim)
 		ExpectNotFound(ctx, env.Client, nodeClaim)
+	})
+	Context("HighScale Profile", func() {
+		It("should use extended registration timeout for HighScale profile", func() {
+			ctxHighScale := options.ToContext(ctx, test.Options(test.OptionsFields{
+				ClusterProfile: lo.ToPtr(options.ClusterProfileHighScale),
+			}))
+			nodeClaim := test.NodeClaim(v1.NodeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						v1.NodePoolLabelKey: nodePool.Name,
+					},
+				},
+				Spec: v1.NodeClaimSpec{
+					Resources: v1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:      resource.MustParse("2"),
+							corev1.ResourceMemory:   resource.MustParse("50Mi"),
+							corev1.ResourcePods:     resource.MustParse("5"),
+							fake.ResourceGPUVendorA: resource.MustParse("1"),
+						},
+					},
+				},
+			})
+			ExpectApplied(ctxHighScale, env.Client, nodePool, nodeClaim)
+			nodeClaim.StatusConditions().SetTrue(v1.ConditionTypeLaunched)
+			ExpectApplied(ctxHighScale, env.Client, nodeClaim)
+			ExpectObjectReconciled(ctxHighScale, env.Client, nodeClaimController, nodeClaim)
+			nodeClaim = ExpectExists(ctxHighScale, env.Client, nodeClaim)
+
+			// Step the clock (should not be deprovisioned with HighScale profile)
+			fakeClock.Step(time.Minute * 20)
+			ExpectObjectReconciled(ctxHighScale, env.Client, nodeClaimController, nodeClaim)
+			ExpectExists(ctxHighScale, env.Client, nodeClaim)
+
+			// Step the clock to total of 65 min (should be deprovisioned with HighScale profile)
+			fakeClock.Step(time.Minute * 45)
+			ExpectObjectReconciled(ctxHighScale, env.Client, nodeClaimController, nodeClaim)
+			ExpectFinalizersRemoved(ctxHighScale, env.Client, nodeClaim)
+			ExpectNotFound(ctxHighScale, env.Client, nodeClaim)
+		})
 	})
 })

--- a/pkg/controllers/state/informer/node.go
+++ b/pkg/controllers/state/informer/node.go
@@ -19,6 +19,7 @@ package informer
 import (
 	"context"
 
+	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	controllerruntime "sigs.k8s.io/controller-runtime"
@@ -29,6 +30,7 @@ import (
 
 	"sigs.k8s.io/karpenter/pkg/controllers/state"
 	"sigs.k8s.io/karpenter/pkg/operator/injection"
+	"sigs.k8s.io/karpenter/pkg/operator/options"
 )
 
 // NodeController reconciles nodes for the purpose of maintaining state regarding nodes that is expensive to compute.
@@ -63,10 +65,13 @@ func (c *NodeController) Reconcile(ctx context.Context, req reconcile.Request) (
 	return reconcile.Result{RequeueAfter: stateRetryPeriod}, nil
 }
 
-func (c *NodeController) Register(_ context.Context, m manager.Manager) error {
+func (c *NodeController) Register(ctx context.Context, m manager.Manager) error {
+	opts := options.FromContext(ctx)
+	highScaleProfile := opts.ClusterProfile == options.ClusterProfileHighScale
+	maxConcurrentReconciles := lo.Ternary(highScaleProfile, 3001, 10)
 	return controllerruntime.NewControllerManagedBy(m).
 		Named("state.node").
 		For(&v1.Node{}).
-		WithOptions(controller.Options{MaxConcurrentReconciles: 10}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 		Complete(c)
 }

--- a/pkg/controllers/state/informer/nodeclaim.go
+++ b/pkg/controllers/state/informer/nodeclaim.go
@@ -19,6 +19,7 @@ package informer
 import (
 	"context"
 
+	"github.com/samber/lo"
 	"k8s.io/apimachinery/pkg/api/errors"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -31,6 +32,7 @@ import (
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 	"sigs.k8s.io/karpenter/pkg/controllers/state"
 	"sigs.k8s.io/karpenter/pkg/operator/injection"
+	"sigs.k8s.io/karpenter/pkg/operator/options"
 	nodeclaimutils "sigs.k8s.io/karpenter/pkg/utils/nodeclaim"
 )
 
@@ -69,10 +71,13 @@ func (c *NodeClaimController) Reconcile(ctx context.Context, req reconcile.Reque
 	return reconcile.Result{RequeueAfter: stateRetryPeriod}, nil
 }
 
-func (c *NodeClaimController) Register(_ context.Context, m manager.Manager) error {
+func (c *NodeClaimController) Register(ctx context.Context, m manager.Manager) error {
+	opts := options.FromContext(ctx)
+	highScaleProfile := opts.ClusterProfile == options.ClusterProfileHighScale
+	maxConcurrentReconciles := lo.Ternary(highScaleProfile, 3001, 10)
 	return controllerruntime.NewControllerManagedBy(m).
 		Named("state.nodeclaim").
 		For(&v1.NodeClaim{}, builder.WithPredicates(nodeclaimutils.IsManagedPredicateFuncs(c.cloudProvider))).
-		WithOptions(controller.Options{MaxConcurrentReconciles: 10}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 		Complete(c)
 }

--- a/pkg/controllers/state/informer/pod.go
+++ b/pkg/controllers/state/informer/pod.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	controllerruntime "sigs.k8s.io/controller-runtime"
@@ -30,6 +31,7 @@ import (
 
 	"sigs.k8s.io/karpenter/pkg/controllers/state"
 	"sigs.k8s.io/karpenter/pkg/operator/injection"
+	"sigs.k8s.io/karpenter/pkg/operator/options"
 )
 
 var stateRetryPeriod = 1 * time.Minute
@@ -68,10 +70,13 @@ func (c *PodController) Reconcile(ctx context.Context, req reconcile.Request) (r
 	return reconcile.Result{RequeueAfter: stateRetryPeriod}, nil
 }
 
-func (c *PodController) Register(_ context.Context, m manager.Manager) error {
+func (c *PodController) Register(ctx context.Context, m manager.Manager) error {
+	opts := options.FromContext(ctx)
+	highScaleProfile := opts.ClusterProfile == options.ClusterProfileHighScale
+	maxConcurrentReconciles := lo.Ternary(highScaleProfile, 3001, 10)
 	return controllerruntime.NewControllerManagedBy(m).
 		Named("state.pod").
 		For(&v1.Pod{}).
-		WithOptions(controller.Options{MaxConcurrentReconciles: 10}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 		Complete(c)
 }

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -44,6 +44,13 @@ const (
 	MinValuesPolicyBestEffort MinValuesPolicy = "BestEffort"
 )
 
+type ClusterProfile string
+
+const (
+	ClusterProfileStandard  ClusterProfile = "Standard"
+	ClusterProfileHighScale ClusterProfile = "HighScale"
+)
+
 var (
 	validLogLevels          = []string{"", "debug", "info", "error"}
 	validPreferencePolicies = []PreferencePolicy{PreferencePolicyIgnore, PreferencePolicyRespect}
@@ -83,6 +90,8 @@ type Options struct {
 	PreferencePolicy        PreferencePolicy
 	minValuesPolicyRaw      string
 	MinValuesPolicy         MinValuesPolicy
+	clusterProfileRaw       string
+	ClusterProfile          ClusterProfile
 	FeatureGates            FeatureGates
 }
 
@@ -122,6 +131,7 @@ func (o *Options) AddFlags(fs *FlagSet) {
 	fs.DurationVar(&o.BatchIdleDuration, "batch-idle-duration", env.WithDefaultDuration("BATCH_IDLE_DURATION", time.Second), "The maximum amount of time with no new pending pods that if exceeded ends the current batching window. If pods arrive faster than this time, the batching window will be extended up to the maxDuration. If they arrive slower, the pods will be batched separately.")
 	fs.StringVar(&o.preferencePolicyRaw, "preference-policy", env.WithDefaultString("PREFERENCE_POLICY", string(PreferencePolicyRespect)), "How the Karpenter scheduler should treat preferences. Preferences include preferredDuringSchedulingIgnoreDuringExecution node and pod affinities/anti-affinities and ScheduleAnyways topologySpreadConstraints. Can be one of 'Ignore' and 'Respect'")
 	fs.StringVar(&o.minValuesPolicyRaw, "min-values-policy", env.WithDefaultString("MIN_VALUES_POLICY", string(MinValuesPolicyStrict)), "Min values policy for scheduling. Options include 'Strict' for existing behavior where min values are strictly enforced or 'BestEffort' where Karpenter relaxes min values when it isn't satisfied.")
+	fs.StringVar(&o.clusterProfileRaw, "cluster-profile", env.WithDefaultString("CLUSTER_PROFILE", string(ClusterProfileStandard)), "Cluster profile for tuning Karpenter's performance characteristics. 'Standard' uses default settings suitable for most clusters. 'HighScale' optimizes for large-scale clusters with many nodes.")
 	fs.StringVar(&o.FeatureGates.inputStr, "feature-gates", env.WithDefaultString("FEATURE_GATES", "NodeRepair=false,ReservedCapacity=true,SpotToSpotConsolidation=false"), "Optional features can be enabled / disabled using feature gates. Current options are: NodeRepair, ReservedCapacity, and SpotToSpotConsolidation.")
 }
 
@@ -141,6 +151,9 @@ func (o *Options) Parse(fs *FlagSet, args ...string) error {
 	if !lo.Contains([]MinValuesPolicy{MinValuesPolicyStrict, MinValuesPolicyBestEffort}, MinValuesPolicy(o.minValuesPolicyRaw)) {
 		return fmt.Errorf("validating cli flags / env vars, invalid MIN_VALUES_POLICY %q", o.minValuesPolicyRaw)
 	}
+	if !lo.Contains([]ClusterProfile{ClusterProfileStandard, ClusterProfileHighScale}, ClusterProfile(o.clusterProfileRaw)) {
+		return fmt.Errorf("validating cli flags / env vars, invalid CLUSTER_PROFILE %q", o.clusterProfileRaw)
+	}
 	if o.CPURequests <= 0 {
 		return fmt.Errorf("validating cli flags / env vars, invalid CPU_REQUESTS %d, must be positive", o.CPURequests)
 	}
@@ -151,6 +164,7 @@ func (o *Options) Parse(fs *FlagSet, args ...string) error {
 	o.FeatureGates = gates
 	o.PreferencePolicy = PreferencePolicy(o.preferencePolicyRaw)
 	o.MinValuesPolicy = MinValuesPolicy(o.minValuesPolicyRaw)
+	o.ClusterProfile = ClusterProfile(o.clusterProfileRaw)
 	return nil
 }
 

--- a/pkg/operator/options/suite_test.go
+++ b/pkg/operator/options/suite_test.go
@@ -62,6 +62,7 @@ var _ = Describe("Options", func() {
 		"BATCH_IDLE_DURATION",
 		"PREFERENCE_POLICY",
 		"MIN_VALUES_POLICY",
+		"CLUSTER_PROFILE",
 		"FEATURE_GATES",
 	}
 
@@ -116,6 +117,7 @@ var _ = Describe("Options", func() {
 				BatchIdleDuration:       lo.ToPtr(time.Second),
 				PreferencePolicy:        lo.ToPtr(options.PreferencePolicyRespect),
 				MinValuesPolicy:         lo.ToPtr(options.MinValuesPolicyStrict),
+				ClusterProfile:          lo.ToPtr(options.ClusterProfileStandard),
 				FeatureGates: test.FeatureGates{
 					ReservedCapacity:        lo.ToPtr(true),
 					NodeRepair:              lo.ToPtr(false),
@@ -146,6 +148,7 @@ var _ = Describe("Options", func() {
 				"--batch-idle-duration", "5s",
 				"--preference-policy", "Ignore",
 				"--min-values-policy", "BestEffort",
+				"--cluster-profile", "HighScale",
 				"--feature-gates", "ReservedCapacity=false,SpotToSpotConsolidation=true,NodeRepair=true",
 			)
 			Expect(err).To(BeNil())
@@ -167,6 +170,7 @@ var _ = Describe("Options", func() {
 				BatchIdleDuration:       lo.ToPtr(5 * time.Second),
 				PreferencePolicy:        lo.ToPtr(options.PreferencePolicyIgnore),
 				MinValuesPolicy:         lo.ToPtr(options.MinValuesPolicyBestEffort),
+				ClusterProfile:          lo.ToPtr(options.ClusterProfileHighScale),
 				FeatureGates: test.FeatureGates{
 					ReservedCapacity:        lo.ToPtr(false),
 					NodeRepair:              lo.ToPtr(true),
@@ -193,6 +197,7 @@ var _ = Describe("Options", func() {
 			os.Setenv("BATCH_IDLE_DURATION", "5s")
 			os.Setenv("PREFERENCE_POLICY", "Ignore")
 			os.Setenv("MIN_VALUES_POLICY", "BestEffort")
+			os.Setenv("CLUSTER_PROFILE", "HighScale")
 			os.Setenv("FEATURE_GATES", "ReservedCapacity=false,SpotToSpotConsolidation=true,NodeRepair=true")
 			fs = &options.FlagSet{
 				FlagSet: flag.NewFlagSet("karpenter", flag.ContinueOnError),
@@ -218,6 +223,7 @@ var _ = Describe("Options", func() {
 				BatchIdleDuration:       lo.ToPtr(5 * time.Second),
 				PreferencePolicy:        lo.ToPtr(options.PreferencePolicyIgnore),
 				MinValuesPolicy:         lo.ToPtr(options.MinValuesPolicyBestEffort),
+				ClusterProfile:          lo.ToPtr(options.ClusterProfileHighScale),
 				FeatureGates: test.FeatureGates{
 					ReservedCapacity:        lo.ToPtr(false),
 					NodeRepair:              lo.ToPtr(true),
@@ -239,6 +245,7 @@ var _ = Describe("Options", func() {
 			os.Setenv("BATCH_IDLE_DURATION", "5s")
 			os.Setenv("PREFERENCE_POLICY", "Ignore")
 			os.Setenv("MIN_VALUES_POLICY", "BestEffort")
+			os.Setenv("CLUSTER_PROFILE", "HighScale")
 			os.Setenv("FEATURE_GATES", "ReservedCapacity=false,SpotToSpotConsolidation=true,NodeRepair=true")
 			fs = &options.FlagSet{
 				FlagSet: flag.NewFlagSet("karpenter", flag.ContinueOnError),
@@ -251,6 +258,7 @@ var _ = Describe("Options", func() {
 				"--log-error-output-paths", "/etc/k8s/testerror",
 				"--preference-policy", "Respect",
 				"--min-values-policy", "Strict",
+				"--cluster-profile", "Standard",
 			)
 			Expect(err).To(BeNil())
 			expectOptionsMatch(opts, test.Options(test.OptionsFields{
@@ -271,6 +279,7 @@ var _ = Describe("Options", func() {
 				BatchIdleDuration:       lo.ToPtr(5 * time.Second),
 				PreferencePolicy:        lo.ToPtr(options.PreferencePolicyRespect),
 				MinValuesPolicy:         lo.ToPtr(options.MinValuesPolicyStrict),
+				ClusterProfile:          lo.ToPtr(options.ClusterProfileStandard),
 				FeatureGates: test.FeatureGates{
 					ReservedCapacity:        lo.ToPtr(false),
 					NodeRepair:              lo.ToPtr(true),
@@ -358,6 +367,7 @@ func expectOptionsMatch(optsA, optsB *options.Options) {
 	Expect(optsA.BatchIdleDuration).To(Equal(optsB.BatchIdleDuration))
 	Expect(optsA.PreferencePolicy).To(Equal(optsB.PreferencePolicy))
 	Expect(optsA.MinValuesPolicy).To(Equal(optsB.MinValuesPolicy))
+	Expect(optsA.ClusterProfile).To(Equal(optsB.ClusterProfile))
 	Expect(optsA.FeatureGates.ReservedCapacity).To(Equal(optsB.FeatureGates.ReservedCapacity))
 	Expect(optsA.FeatureGates.NodeRepair).To(Equal(optsB.FeatureGates.NodeRepair))
 	Expect(optsA.FeatureGates.SpotToSpotConsolidation).To(Equal(optsB.FeatureGates.SpotToSpotConsolidation))

--- a/pkg/test/options.go
+++ b/pkg/test/options.go
@@ -44,6 +44,7 @@ type OptionsFields struct {
 	LogErrorOutputPaths     *string
 	PreferencePolicy        *options.PreferencePolicy
 	MinValuesPolicy         *options.MinValuesPolicy
+	ClusterProfile          *options.ClusterProfile
 	BatchMaxDuration        *time.Duration
 	BatchIdleDuration       *time.Duration
 	FeatureGates            FeatureGates
@@ -80,6 +81,7 @@ func Options(overrides ...OptionsFields) *options.Options {
 		BatchIdleDuration:     lo.FromPtrOr(opts.BatchIdleDuration, time.Second),
 		PreferencePolicy:      lo.FromPtrOr(opts.PreferencePolicy, options.PreferencePolicyRespect),
 		MinValuesPolicy:       lo.FromPtrOr(opts.MinValuesPolicy, options.MinValuesPolicyStrict),
+		ClusterProfile:        lo.FromPtrOr(opts.ClusterProfile, options.ClusterProfileStandard),
 		FeatureGates: options.FeatureGates{
 			NodeRepair:              lo.FromPtrOr(opts.FeatureGates.NodeRepair, false),
 			ReservedCapacity:        lo.FromPtrOr(opts.FeatureGates.ReservedCapacity, true),


### PR DESCRIPTION
Fixes #N/A

**Description**
This change adds an environment variable option called `ClusterProfile` with the following definitions:
* `HighScale`: Parameters for some controllers such as `maxConcurrentReconciles`, `maxRetryDuration`, and `registrationTimeout` are tuned for high scale clusters. Rate limiters on some controllers are also changed. Additionally, controller metrics are disabled.
* `Standard`: Default values and rate limiters are used.

A summary of tuning changes made for High Scale Clusters:
```
Disruption Queue Controller
* maxConcurrentReconciles: 100 --> 1000
* maxRetryDuration: 10 min --> 60 min

Node Health Controller
* rate limiter changes

Node Termination Controller
* rate limiter changes
* maxConcurrentReconciles: 100 --> 5000

Node Terminator Eviction Controller
* rate limiter changes
* maxConcurrentReconciles: 100 --> 5000

NodeClaim Lifecycle Controller
* rate limiter changes
* maxConcurrentReconciles: 1000 --> 5000

NodeClaim Lifecycle Liveness Controller
* registrationTimeout: 15 min --> 60 min

Node, NodeClaim, and Pod State Informer Controllers
* maxConcurrentReconciles: 10 --> 3001
```

**How was this change tested?**
`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.